### PR TITLE
fix location to slice2py

### DIFF
--- a/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
+++ b/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
@@ -236,7 +236,11 @@ class SliceExtension {
         def getSlice2py(iceHome) {
             def os = System.properties['os.name']
             if (os == "Mac OS X") {
-                return getSliceCompiler("slice2py", [iceHome, "libexec"].join(File.separator))
+                if (SliceExtension.compareVersions(_iceVersion, '3.7') >= 0) {
+                    return getSliceCompiler("slice2py", [iceHome, "libexec"].join(File.separator))
+                } else {
+                    return getSliceCompiler("slice2py", iceHome)
+                }
             } else {
                 return getSliceCompiler("slice2py", iceHome)
             }

--- a/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
+++ b/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
@@ -234,7 +234,12 @@ class SliceExtension {
         }
 
         def getSlice2py(iceHome) {
-            return getSliceCompiler("slice2py", iceHome)
+            def os = System.properties['os.name']
+            if (os == "Mac OS X") {
+                return getSliceCompiler("slice2py", [iceHome, "libexec"].join(File.separator))
+            } else {
+                return getSliceCompiler("slice2py", iceHome)
+            }
         }
 
         def getSlice2java(iceHome) {


### PR DESCRIPTION
Slice2py is now available  under ``/usr/local/opt/ice/libexec/bin`` on Mac