### PR TITLE
add set up to deploy

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,3 +51,49 @@ jobs:
         shell: bash
       - name: Run commands
         run: ./gradlew ${{ env.gradle_commands }}
+  deploy:
+    if: startsWith(github.ref, 'refs/tags')
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      gradle_version: 5.2.1 # set to empty to build with most recent version of gradle
+      gradle_commands: publish # default is build
+      ICE_HOME: /opt/ice-3.6.5 # location where Ice is installed
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Install slice2java
+        run: |
+            sudo apt-get install -y libmcpp-dev
+            wget -q https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+            tar xf ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+            mv ice-3.6.5-0.2.0 ice-3.6.5
+            mv ice-3.6.5 /opt
+            rm ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+            echo "${{ env.ICE_HOME }}/bin" >> $GITHUB_PATH
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Wrap with specified version
+        run: |
+          gradle wrapper --gradle-version=${{ env.gradle_version }}
+        if: ${{ env.gradle_version != '' }}
+        shell: bash
+      - name: Wrap without version
+        run: |
+          gradle wrapper
+        if: ${{ env.gradle_version == '' }}
+        shell: bash
+      - name: Run commands
+        run: |
+          ./gradlew ${{ env.gradle_commands }}
+        env:
+          ARTIFACTORY_URL: ${{ secrets.CI_DEPLOY_URL }}
+          ARTIFACTORY_USER: ${{ secrets.CI_DEPLOY_USER }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.CI_DEPLOY_PASS }}

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ sourceSets {
     }
 }
 
-version  = "1.5.3-SNAPSHOT"
+version  = "1.5.3-m1"
 group = "org.openmicroscopy.gradle.ice-builder"
 
 gradlePlugin {


### PR DESCRIPTION
Following the problem encountered yesterday, this PR allows to deploy to https://artifacts.openmicroscopy.org/ when a new tag is pushed using  a different Gradle version that the one user
A few repositories (including this one) do a "double-push", this implies that the CI_USER must be an admin
3 secrets are used the URL, PASS, USER
This PR has been tested from my fork and artifact pushed to ``ome.staging``
If we are okay with this and the USER/admin limitation, I will roll it out to other repositories
cc @sbesson @joshmoore 